### PR TITLE
Clarify network setup wording

### DIFF
--- a/docs/quick_start/quick_start.md
+++ b/docs/quick_start/quick_start.md
@@ -184,8 +184,8 @@ You can use ROS 2 service to change payload value or payload compensation on the
 
 ### Driver Network Configuration
 
-The ROS 2 Control Driver requires a network connection to the robot, which can be either port 1 or port 2.
-It is recommended that the ROS 2 network be on a port that is isolated from all other Ethernet communications.
+The ros2_control Driver requires a network connection to the robot, which can be either port 1 or port 2.
+It is recommended that the ros2_control network to the robot be on a port that is isolated from all other Ethernet communications.
 
 First, we will set IP addresses for each of the Ethernet connections.
 


### PR DESCRIPTION
Dear Fanuc Maintainers,

a small contribution that clarifies the wording in the network setup. The previously written sentence is, in my opinion, wrong, as you don't communicate over ROS 2 to the robot, and you want actual ROS 2 traffic (to other computers) to be separated from the traffic between ros2_control and the robot.

Cheers,

Dr. Denis